### PR TITLE
fix:워크스페이스 라우터 수정, 업무삭제 버그수정

### DIFF
--- a/controllers/Ctodos.js
+++ b/controllers/Ctodos.js
@@ -86,21 +86,37 @@ exports.patchTodo = async (req, res) => {
 exports.deleteTodo = async (req, res) => {
   try {
     const { todo_id } = req.params;
-
     // 삭제 전 삭제할 데이터가 존재하는지 확인인
     const todo = await todoModel.findByPk(todo_id);
+
+    // 업무 참여자 삭제
+    await workerModel.destroy({
+      where: { todo_id: todo_id },
+    });
+
+    // todo 삭제
+    await todo.destroy();
+  
     if (!todo) {
-      return res.send(
-        responseUtil('ERROR', '해당 업무를 찾을 수 없습니다.', null)
-      );
+      return res.status(404).send({
+        status: "ERROR",
+        message: "해당 업무를 찾을 수 없습니다.",
+        data: null,
+      });
     }
 
-    // 해당 데이터 삭제 (기존 조회했던 데이터 기준으로 삭제)
-    await todo.destroy();
-    res.send(responseUtil('SUCCESS', '업무 삭제 성공했습니다.', null));
+    res.send({
+      status: "SUCCESS",
+      message: "업무 삭제 성공",
+      data: null,
+    });
   } catch (err) {
     console.error(err);
-    res.send(responseUtil('ERROR', '업무 삭제에 실패하였습니다.', null));
+    res.status(500).send({
+      status: "ERROR",
+      message: "업무 삭제에 실패하였습니다.",
+      data: null,
+    });
   }
 };
 

--- a/routes/workspace.js
+++ b/routes/workspace.js
@@ -6,23 +6,23 @@ const isAuthenticated = require('../middlewares/isAuthenticated'); // 로그인 
 // workspace 라우터의 기본 URL은 workspace/ 입니다!!!
 /* 컨트롤러의 이름은 임의로 설정하였으니 각각 용도에 맞춰 작성해주세요~ 😀 */
 
-// 워크스페이스 생성 (POST)
+// 워크스페이스 생성
 router.post("/", isAuthenticated, controller.postSpaceCreate);
 
 // 현재 사용자가 참여한 모든 워크스페이스 조회 (GET)
 router.get("/user", isAuthenticated, controller.getMySpace);
 
-// 워크스페이스 초대 (POST가 적절)
+// 워크스페이스 초대 
 router.post("/invite", isAuthenticated, controller.postSpaceInvite);
 
 // 워크스페이스 참여 신청 (초대 코드 입력 후 참여)
 router.post("/join", isAuthenticated, controller.postSpaceJoin);
 
-// 특정 워크스페이스 조회 (GET)
+// 특정 워크스페이스 조회 
 router.get("/:space_id", isAuthenticated, controller.getSpace);
 
-// 특정 워크스페이스 멤버 조회 (GET이 더 적절)
-router.post("/:space_id/member", isAuthenticated, controller.postSpaceMember);
+// 특정 워크스페이스 멤버 조회 
+router.get("/:space_id/member", isAuthenticated, controller.getSpaceMember);
 
 
 module.exports = router;


### PR DESCRIPTION
## 📌 PR 개요
- 이 PR에서 해결한 내용을 간략하게 설명해주세요.

## 🔄 변경 사항
- 특정 워크스페이스의 멤버를 조회할때 post 방식에서 get방식으로 변경함
- 업무 삭제 시 업무 참여자 테이블 외래 키로 인한 삭제 오류 수정 업무에 참여한 멤버 데이터를 삭제 후 업무를 삭제하는 방식으로 변경


